### PR TITLE
test(MKN-12): unit tests auth service

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,7 +80,10 @@
       "**/*.(t|j)s"
     ],
     "coverageDirectory": "../coverage",
-    "testEnvironment": "node"
+    "testEnvironment": "node",
+    "moduleNameMapper": {
+      "^src/(.*)$": "<rootDir>/$1"
+    }
   },
   "lint-staged": {
     "*.{ts,js}": [

--- a/src/modules/auth/application/auth.service.spec.ts
+++ b/src/modules/auth/application/auth.service.spec.ts
@@ -12,6 +12,7 @@ import { RefreshToken } from '../domain/entities/refresh-token.entity';
 
 describe('AuthService', () => {
   let service: AuthService;
+  let mockUser: User;
 
   const mockUserRepository = {
     findByEmail: jest.fn(),
@@ -31,6 +32,18 @@ describe('AuthService', () => {
     verifyRefreshToken: jest.fn(),
   } as jest.Mocked<TokenService>;
 
+  beforeAll(async () => {
+    const hashedPassword = await bcrypt.hash('pass', 10);
+
+    mockUser = new User({
+      id: 'user-1',
+      email: 'test@test.com',
+      name: 'test',
+      last_name: 'test1',
+      password_hash: hashedPassword,
+    });
+  });
+
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
@@ -48,14 +61,6 @@ describe('AuthService', () => {
     jest.clearAllMocks();
   });
 
-  const mockUser = new User({
-    id: 'user-1',
-    email: 'test@test.com',
-    name: 'test',
-    last_name: 'test1',
-    password_hash: 'pa$$',
-  });
-
   // ─── register ──────────────────────────────────────────────────────────────
 
   describe('register', () => {
@@ -70,14 +75,7 @@ describe('AuthService', () => {
         password: 'pass',
       });
 
-      expect(result).toEqual(
-        expect.objectContaining({
-          id: 'user-1',
-          email: 'test@test.com',
-          name: 'test',
-          last_name: 'test1',
-        }),
-      );
+      expect(result).toEqual(mockUser);
       expect(mockUserRepository.create).toHaveBeenCalledTimes(1);
     });
 

--- a/src/modules/auth/application/auth.service.spec.ts
+++ b/src/modules/auth/application/auth.service.spec.ts
@@ -1,0 +1,201 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ConflictException, UnauthorizedException } from '@nestjs/common';
+import bcrypt from 'bcryptjs';
+import { AuthService } from './auth.service';
+
+jest.mock('bcryptjs');
+import { UsersRepository } from 'src/modules/users/domain/repository/user.repository';
+import { AuthRepository } from '../domain/repository/auth.repository';
+import { TokenService } from '../domain/services/token.services';
+import { User } from 'src/modules/users/domain/entities/user.entity';
+import { RefreshToken } from '../domain/entities/refresh-token.entity';
+
+describe('AuthService', () => {
+  let service: AuthService;
+
+  const mockUserRepository = {
+    findByEmail: jest.fn(),
+    create: jest.fn(),
+  } as jest.Mocked<UsersRepository>;
+
+  const mockAuthRepository = {
+    save: jest.fn(),
+    findByToken: jest.fn(),
+    deleteByToken: jest.fn(),
+    deleteByFamily: jest.fn(),
+  } as jest.Mocked<AuthRepository>;
+
+  const mockTokenService = {
+    generateAccessToken: jest.fn(),
+    generateRefreshToken: jest.fn(),
+    verifyRefreshToken: jest.fn(),
+  } as jest.Mocked<TokenService>;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        AuthService,
+        { provide: UsersRepository, useValue: mockUserRepository },
+        { provide: AuthRepository, useValue: mockAuthRepository },
+        { provide: TokenService, useValue: mockTokenService },
+      ],
+    }).compile();
+
+    service = module.get<AuthService>(AuthService);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  const mockUser = new User({
+    id: 'user-1',
+    email: 'test@test.com',
+    name: 'test',
+    last_name: 'test1',
+    password_hash: 'pa$$',
+  });
+
+  // ─── register ──────────────────────────────────────────────────────────────
+
+  describe('register', () => {
+    it('should register a user', async () => {
+      mockUserRepository.findByEmail.mockResolvedValue(null);
+      mockUserRepository.create.mockResolvedValue(mockUser);
+
+      const result = await service.register({
+        email: 'test@test.com',
+        last_name: 'test1',
+        name: 'test',
+        password: 'pass',
+      });
+
+      expect(result).toEqual(
+        expect.objectContaining({
+          id: 'user-1',
+          email: 'test@test.com',
+          name: 'test',
+          last_name: 'test1',
+        }),
+      );
+      expect(mockUserRepository.create).toHaveBeenCalledTimes(1);
+    });
+
+    it('should throw ConflictException if email already exists', async () => {
+      mockUserRepository.findByEmail.mockResolvedValue(mockUser);
+
+      await expect(
+        service.register({
+          email: 'test@test.com',
+          last_name: 'test1',
+          name: 'test',
+          password: 'pass',
+        }),
+      ).rejects.toThrow(ConflictException);
+
+      expect(mockUserRepository.create).not.toHaveBeenCalled();
+    });
+  });
+
+  // ─── login ─────────────────────────────────────────────────────────────────
+
+  describe('login', () => {
+    const loginInput = {
+      email: 'test@test.com',
+      password: 'pass',
+      ip_address: '127.0.0.1',
+      user_agent: 'jest',
+    };
+
+    it('should return tokens and user on valid credentials', async () => {
+      mockUserRepository.findByEmail.mockResolvedValue(mockUser);
+      jest.mocked(bcrypt.compare).mockResolvedValue(true as never);
+      mockTokenService.generateAccessToken.mockReturnValue('access-token');
+      mockTokenService.generateRefreshToken.mockReturnValue('refresh-token');
+      mockAuthRepository.save.mockResolvedValue(
+        new RefreshToken({
+          id: 'rt-1',
+          user_id: mockUser.id,
+          token_hash: 'hash',
+          family: 'family-uuid',
+          expires_at: new Date(Date.now() + 60_000),
+        }),
+      );
+
+      const result = await service.login(loginInput);
+
+      expect(result.access_token).toBe('access-token');
+      expect(result.refresh_token).toBe('refresh-token');
+      expect(result.user).toEqual(expect.objectContaining({ email: mockUser.email }));
+    });
+
+    it('should throw UnauthorizedException if user not found', async () => {
+      mockUserRepository.findByEmail.mockResolvedValue(null);
+
+      await expect(service.login(loginInput)).rejects.toThrow(UnauthorizedException);
+    });
+
+    it('should throw UnauthorizedException if password is wrong', async () => {
+      mockUserRepository.findByEmail.mockResolvedValue(mockUser);
+      jest.mocked(bcrypt.compare).mockResolvedValue(false as never);
+
+      await expect(service.login(loginInput)).rejects.toThrow(UnauthorizedException);
+      expect(mockAuthRepository.save).not.toHaveBeenCalled();
+    });
+  });
+
+  // ─── refreshToken ──────────────────────────────────────────────────────────
+
+  describe('refreshToken', () => {
+    const refreshInput = {
+      token: 'raw-refresh-token',
+      user_id: 'user-1',
+      family: 'family-uuid',
+      ip_address: '127.0.0.1',
+      user_agent: 'jest',
+    };
+
+    const validToken = new RefreshToken({
+      id: 'rt-1',
+      user_id: 'user-1',
+      token_hash: 'some-hash',
+      family: 'family-uuid',
+      expires_at: new Date(Date.now() + 60_000),
+    });
+
+    const expiredToken = new RefreshToken({
+      id: 'rt-2',
+      user_id: 'user-1',
+      token_hash: 'some-hash',
+      family: 'family-uuid',
+      expires_at: new Date(Date.now() - 60_000),
+    });
+
+    it('should return new tokens and rotate the refresh token', async () => {
+      mockAuthRepository.findByToken.mockResolvedValue(validToken);
+      mockTokenService.generateAccessToken.mockReturnValue('new-access-token');
+      mockTokenService.generateRefreshToken.mockReturnValue('new-refresh-token');
+      mockAuthRepository.save.mockResolvedValue(new RefreshToken({ ...validToken, id: 'rt-2' }));
+
+      const result = await service.refreshToken(refreshInput);
+
+      expect(result.access_token).toBe('new-access-token');
+      expect(result.refresh_token).toBe('new-refresh-token');
+      expect(mockAuthRepository.deleteByToken).toHaveBeenCalledTimes(1);
+    });
+
+    it('should throw UnauthorizedException and delete family on token reuse', async () => {
+      mockAuthRepository.findByToken.mockResolvedValue(null);
+
+      await expect(service.refreshToken(refreshInput)).rejects.toThrow(UnauthorizedException);
+      expect(mockAuthRepository.deleteByFamily).toHaveBeenCalledWith(refreshInput.family);
+    });
+
+    it('should throw UnauthorizedException if token is expired', async () => {
+      mockAuthRepository.findByToken.mockResolvedValue(expiredToken);
+
+      await expect(service.refreshToken(refreshInput)).rejects.toThrow(UnauthorizedException);
+      expect(mockAuthRepository.deleteByToken).not.toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add unit tests for `register`, `login`, and `refreshToken` in `AuthService`
- Add `moduleNameMapper` to Jest config to resolve `src/` path aliases

## Test plan
- [ ] `pnpm test src/modules/auth/application/auth.service.spec.ts` — 8 tests pass

Closes #12

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded unit test coverage for authentication flows: registration, login, and refresh-token scenarios, including success and error paths.

* **Chores**
  * Updated test configuration to improve module resolution for the test runner.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->