### PR TITLE
fix(MKN-85): todo auth guard and ownership

### DIFF
--- a/src/modules/todo/application/use-cases/delete.use-case.spec.ts
+++ b/src/modules/todo/application/use-cases/delete.use-case.spec.ts
@@ -39,23 +39,36 @@ describe('DeleteUseCase', () => {
     it('throws NotFoundException and does NOT call delete when the todo does not exist', async () => {
       repository.findById.mockResolvedValue(null);
 
-      await expect(useCase.execute('missing-id')).rejects.toThrow(
+      await expect(useCase.execute('missing-id', 'user-1')).rejects.toThrow(
         new NotFoundException('Todo not found'),
       );
 
-      expect(repository.findById).toHaveBeenCalledWith('missing-id');
+      expect(repository.findById).toHaveBeenCalledWith('missing-id', 'user-1');
+      expect(repository.delete).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('cross-user access', () => {
+    it('does NOT delete a todo that belongs to another user', async () => {
+      repository.findById.mockResolvedValue(null);
+
+      await expect(useCase.execute('todo-1', 'user-2')).rejects.toThrow(
+        new NotFoundException('Todo not found'),
+      );
+
+      expect(repository.findById).toHaveBeenCalledWith('todo-1', 'user-2');
       expect(repository.delete).not.toHaveBeenCalled();
     });
   });
 
   describe('happy path', () => {
-    it('calls repository.delete with the id when the todo exists', async () => {
+    it('calls repository.delete with the id when the caller owns the todo', async () => {
       repository.findById.mockResolvedValue(makeTodo());
       repository.delete.mockResolvedValue(undefined);
 
-      await expect(useCase.execute('todo-1')).resolves.toBeUndefined();
+      await expect(useCase.execute('todo-1', 'user-1')).resolves.toBeUndefined();
 
-      expect(repository.findById).toHaveBeenCalledWith('todo-1');
+      expect(repository.findById).toHaveBeenCalledWith('todo-1', 'user-1');
       expect(repository.delete).toHaveBeenCalledTimes(1);
       expect(repository.delete).toHaveBeenCalledWith('todo-1');
     });

--- a/src/modules/todo/application/use-cases/delete.use-case.ts
+++ b/src/modules/todo/application/use-cases/delete.use-case.ts
@@ -5,8 +5,8 @@ import { TodoRepository } from '../../domain/repository/todo.repository';
 export class DeleteUseCase {
   constructor(private readonly todoRepository: TodoRepository) {}
 
-  async execute(id: string) {
-    const todo = await this.todoRepository.findById(id);
+  async execute(id: string, owner_user_id: string) {
+    const todo = await this.todoRepository.findById(id, owner_user_id);
 
     if (!todo) throw new NotFoundException('Todo not found');
 

--- a/src/modules/todo/application/use-cases/find-all.use-case.spec.ts
+++ b/src/modules/todo/application/use-cases/find-all.use-case.spec.ts
@@ -1,6 +1,6 @@
 import { FindAllUseCase } from './find-all.use-case';
 import { TodoRepository } from '../../domain/repository/todo.repository';
-import { PaginationParams, PaginationResult } from 'src/shared/domain/pagination';
+import { PaginationResult } from 'src/shared/domain/pagination';
 import { Todo } from '../../domain/entities/todo.entity';
 import { TodoStatus } from '../../domain/entities/todo.entity.types';
 
@@ -25,26 +25,34 @@ const makeTodo = (overrides: Partial<Todo> = {}): Todo =>
 
 describe('FindAllUseCase', () => {
   let useCase: FindAllUseCase;
-  let repository: jest.Mocked<Pick<TodoRepository, 'findAll'>>;
+  let repository: jest.Mocked<Pick<TodoRepository, 'findAllByOwnerUserId'>>;
 
   beforeEach(() => {
     repository = {
-      findAll: jest.fn(),
+      findAllByOwnerUserId: jest.fn(),
     };
     useCase = new FindAllUseCase(repository as unknown as TodoRepository);
   });
 
-  // This use-case is a thin delegator: it must forward params untouched and
-  // return the repository's PaginationResult verbatim.
-  it('delegates to repository.findAll with the params and returns its result', async () => {
-    const params: PaginationParams = { offset: 0, limit: 10 };
+  it('scopes the listing to the owner and forwards only the pagination params', async () => {
     const paginated: PaginationResult<Todo[]> = { data: [makeTodo()], total: 1 };
-    repository.findAll.mockResolvedValue(paginated);
+    repository.findAllByOwnerUserId.mockResolvedValue(paginated);
 
-    const result = await useCase.execute(params);
+    const result = await useCase.execute({ offset: 0, limit: 10, owner_user_id: 'user-1' });
 
-    expect(repository.findAll).toHaveBeenCalledTimes(1);
-    expect(repository.findAll).toHaveBeenCalledWith(params);
+    expect(repository.findAllByOwnerUserId).toHaveBeenCalledTimes(1);
+    expect(repository.findAllByOwnerUserId).toHaveBeenCalledWith('user-1', {
+      offset: 0,
+      limit: 10,
+    });
     expect(result).toBe(paginated);
+  });
+
+  it('never queries without an owner', async () => {
+    repository.findAllByOwnerUserId.mockResolvedValue({ data: [], total: 0 });
+
+    await useCase.execute({ offset: 0, limit: 10, owner_user_id: 'user-2' });
+
+    expect(repository.findAllByOwnerUserId).toHaveBeenCalledWith('user-2', expect.anything());
   });
 });

--- a/src/modules/todo/application/use-cases/find-all.use-case.ts
+++ b/src/modules/todo/application/use-cases/find-all.use-case.ts
@@ -2,11 +2,15 @@ import { Injectable } from '@nestjs/common';
 import { TodoRepository } from '../../domain/repository/todo.repository';
 import { PaginationParams } from 'src/shared/domain/pagination';
 
+type FindAllInput = PaginationParams & {
+  owner_user_id: string;
+};
+
 @Injectable()
 export class FindAllUseCase {
   constructor(private readonly todoRepository: TodoRepository) {}
 
-  async execute(params: PaginationParams) {
-    return await this.todoRepository.findAll(params);
+  async execute({ owner_user_id, ...params }: FindAllInput) {
+    return await this.todoRepository.findAllByOwnerUserId(owner_user_id, params);
   }
 }

--- a/src/modules/todo/application/use-cases/find-by-id.use-case.spec.ts
+++ b/src/modules/todo/application/use-cases/find-by-id.use-case.spec.ts
@@ -38,22 +38,34 @@ describe('FindByIdUseCase', () => {
     it('throws NotFoundException when the repository returns null', async () => {
       repository.findById.mockResolvedValue(null);
 
-      await expect(useCase.execute('missing-id')).rejects.toThrow(
+      await expect(useCase.execute('missing-id', 'user-1')).rejects.toThrow(
         new NotFoundException('Todo not found'),
       );
 
-      expect(repository.findById).toHaveBeenCalledWith('missing-id');
+      expect(repository.findById).toHaveBeenCalledWith('missing-id', 'user-1');
+    });
+  });
+
+  describe('cross-user access', () => {
+    it('throws NotFoundException when the todo belongs to another user', async () => {
+      repository.findById.mockResolvedValue(null);
+
+      await expect(useCase.execute('todo-1', 'user-2')).rejects.toThrow(
+        new NotFoundException('Todo not found'),
+      );
+
+      expect(repository.findById).toHaveBeenCalledWith('todo-1', 'user-2');
     });
   });
 
   describe('happy path', () => {
-    it('returns the todo when the repository finds one', async () => {
+    it('returns the todo when the caller owns it', async () => {
       const todo = makeTodo();
       repository.findById.mockResolvedValue(todo);
 
-      const result = await useCase.execute('todo-1');
+      const result = await useCase.execute('todo-1', 'user-1');
 
-      expect(repository.findById).toHaveBeenCalledWith('todo-1');
+      expect(repository.findById).toHaveBeenCalledWith('todo-1', 'user-1');
       expect(result).toBe(todo);
     });
   });

--- a/src/modules/todo/application/use-cases/find-by-id.use-case.ts
+++ b/src/modules/todo/application/use-cases/find-by-id.use-case.ts
@@ -5,8 +5,8 @@ import { TodoRepository } from '../../domain/repository/todo.repository';
 export class FindByIdUseCase {
   constructor(private readonly todoRepository: TodoRepository) {}
 
-  async execute(id: string) {
-    const todo = await this.todoRepository.findById(id);
+  async execute(id: string, owner_user_id: string) {
+    const todo = await this.todoRepository.findById(id, owner_user_id);
 
     if (!todo) {
       throw new NotFoundException('Todo not found');

--- a/src/modules/todo/application/use-cases/update.use-case.spec.ts
+++ b/src/modules/todo/application/use-cases/update.use-case.spec.ts
@@ -46,26 +46,39 @@ describe('UpdateUseCase', () => {
     it('throws NotFoundException and does NOT call update when the todo does not exist', async () => {
       repository.findById.mockResolvedValue(null);
 
-      await expect(useCase.execute(baseInput)).rejects.toThrow(
+      await expect(useCase.execute({ ...baseInput, owner_user_id: 'user-1' })).rejects.toThrow(
         new NotFoundException('Todo not found'),
       );
 
-      expect(repository.findById).toHaveBeenCalledWith('todo-1');
+      expect(repository.findById).toHaveBeenCalledWith('todo-1', 'user-1');
+      expect(repository.update).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('cross-user access', () => {
+    it('does NOT update a todo that belongs to another user', async () => {
+      repository.findById.mockResolvedValue(null);
+
+      await expect(useCase.execute({ ...baseInput, owner_user_id: 'user-2' })).rejects.toThrow(
+        new NotFoundException('Todo not found'),
+      );
+
+      expect(repository.findById).toHaveBeenCalledWith('todo-1', 'user-2');
       expect(repository.update).not.toHaveBeenCalled();
     });
   });
 
   describe('happy path', () => {
-    it('calls repository.update with the input and returns its result when the todo exists', async () => {
+    it('updates and returns the result when the caller owns the todo', async () => {
       // The existing todo must be found first; the updated todo is what the repo returns.
       const existing = makeTodo();
       const updated = makeTodo({ title: 'Buy oat milk' });
       repository.findById.mockResolvedValue(existing);
       repository.update.mockResolvedValue(updated);
 
-      const result = await useCase.execute(baseInput);
+      const result = await useCase.execute({ ...baseInput, owner_user_id: 'user-1' });
 
-      expect(repository.findById).toHaveBeenCalledWith('todo-1');
+      expect(repository.findById).toHaveBeenCalledWith('todo-1', 'user-1');
       expect(repository.update).toHaveBeenCalledTimes(1);
       expect(repository.update).toHaveBeenCalledWith(baseInput);
       expect(result).toBe(updated);

--- a/src/modules/todo/application/use-cases/update.use-case.ts
+++ b/src/modules/todo/application/use-cases/update.use-case.ts
@@ -2,11 +2,16 @@ import { Injectable, NotFoundException } from '@nestjs/common';
 import { TodoRepository } from '../../domain/repository/todo.repository';
 import { UpdateTodoInput } from '../../domain/repository/todo.repository.type';
 
+type UpdateInput = UpdateTodoInput & {
+  owner_user_id: string;
+};
+
 @Injectable()
 export class UpdateUseCase {
   constructor(private readonly todoRepository: TodoRepository) {}
-  async execute(input: UpdateTodoInput) {
-    const todo = await this.todoRepository.findById(input.id);
+
+  async execute({ owner_user_id, ...input }: UpdateInput) {
+    const todo = await this.todoRepository.findById(input.id, owner_user_id);
 
     if (!todo) throw new NotFoundException('Todo not found');
 

--- a/src/modules/todo/domain/repository/todo.repository.ts
+++ b/src/modules/todo/domain/repository/todo.repository.ts
@@ -3,7 +3,7 @@ import { Todo } from '../entities/todo.entity';
 import { CreateTodoInput, UpdateTodoInput } from './todo.repository.type';
 
 export abstract class TodoRepository {
-  abstract findById(id: string): Promise<Todo | null>;
+  abstract findById(id: string, owner_user_id: string): Promise<Todo | null>;
   abstract findAllByOwnerUserId(
     owner_user_id: string,
     params: PaginationParams,
@@ -12,7 +12,6 @@ export abstract class TodoRepository {
     assigned_user_id: string,
     params: PaginationParams,
   ): Promise<PaginationResult<Todo[]>>;
-  abstract findAll(params: PaginationParams): Promise<PaginationResult<Todo[]>>;
   abstract create(todo: CreateTodoInput): Promise<Todo>;
   abstract update(todo: UpdateTodoInput): Promise<Todo>;
   abstract delete(id: string): Promise<void>;

--- a/src/modules/todo/infrastructure/http/dto/find.dto.ts
+++ b/src/modules/todo/infrastructure/http/dto/find.dto.ts
@@ -1,12 +1,8 @@
 import { TodoStatus } from '@prisma/client';
-import { IsOptional, IsUUID, IsEnum } from 'class-validator';
+import { IsOptional, IsEnum } from 'class-validator';
 import { PaginationDto } from 'src/shared/infrastructure/http/pagination.dto';
 
 export class FindTodoDto extends PaginationDto {
-  @IsOptional()
-  @IsUUID()
-  owner_user_id?: string;
-
   @IsOptional()
   @IsEnum(TodoStatus)
   status?: TodoStatus;

--- a/src/modules/todo/infrastructure/http/todo.controller.ts
+++ b/src/modules/todo/infrastructure/http/todo.controller.ts
@@ -12,6 +12,7 @@ import { UpdateTodoDto } from './dto/update.dto';
 import { FindTodoDto } from './dto/find.dto';
 
 @Controller('todo')
+@UseGuards(JwtAuthGuard)
 export class TodoController {
   constructor(
     private readonly createUseCase: CreateUseCase,
@@ -22,12 +23,14 @@ export class TodoController {
   ) {}
 
   @Get()
-  async findAll(@Body() findTodoDto: FindTodoDto) {
-    return this.findAllUseCase.execute(findTodoDto);
+  async findAll(@Body() findTodoDto: FindTodoDto, @CurrentUser() user: JwtUserPayload) {
+    return this.findAllUseCase.execute({
+      ...findTodoDto,
+      owner_user_id: user.user_id,
+    });
   }
 
   @Post()
-  @UseGuards(JwtAuthGuard)
   async create(@Body() createTodoDto: CreateTodoDto, @CurrentUser() user: JwtUserPayload) {
     return this.createUseCase.execute({
       ...createTodoDto,
@@ -36,19 +39,27 @@ export class TodoController {
   }
 
   @Patch(':id')
-  async update(@Param('id') id: string, @Body() updateTodoDto: UpdateTodoDto) {
-    return this.updateUseCase.execute({ id, ...updateTodoDto });
+  async update(
+    @Param('id') id: string,
+    @Body() updateTodoDto: UpdateTodoDto,
+    @CurrentUser() user: JwtUserPayload,
+  ) {
+    return this.updateUseCase.execute({
+      id,
+      ...updateTodoDto,
+      owner_user_id: user.user_id,
+    });
   }
 
   @Get(':id')
-  async findById(@Param('id') id: string) {
+  async findById(@Param('id') id: string, @CurrentUser() user: JwtUserPayload) {
     // Let the use-case's NotFoundException propagate as a real 404
     // instead of masking every error as a 400.
-    return this.findByIdUseCase.execute(id);
+    return this.findByIdUseCase.execute(id, user.user_id);
   }
 
   @Delete(':id')
-  async delete(@Param('id') id: string) {
-    return this.deleteUseCase.execute(id);
+  async delete(@Param('id') id: string, @CurrentUser() user: JwtUserPayload) {
+    return this.deleteUseCase.execute(id, user.user_id);
   }
 }

--- a/src/modules/todo/infrastructure/persistence/prisma-todo.repository.ts
+++ b/src/modules/todo/infrastructure/persistence/prisma-todo.repository.ts
@@ -9,9 +9,9 @@ import { Injectable } from '@nestjs/common';
 export class PrismaTodoRepository implements TodoRepository {
   constructor(private readonly prismaService: PrismaService) {}
 
-  async findById(id: string): Promise<Todo | null> {
-    const existingTodo = await this.prismaService.todo.findUnique({
-      where: { id },
+  async findById(id: string, owner_user_id: string): Promise<Todo | null> {
+    const existingTodo = await this.prismaService.todo.findFirst({
+      where: { id, owner_user_id },
     });
 
     if (!existingTodo) return null;
@@ -34,24 +34,6 @@ export class PrismaTodoRepository implements TodoRepository {
     });
 
     return new Todo(createdTodo);
-  }
-
-  async findAll({ limit, offset }: PaginationParams): Promise<PaginationResult<Todo[]>> {
-    const [todos, total] = await this.prismaService.$transaction([
-      this.prismaService.todo.findMany({
-        orderBy: { created_at: 'desc' },
-        skip: offset,
-        take: limit,
-      }),
-      this.prismaService.todo.count({
-        where: {},
-      }),
-    ]);
-
-    return {
-      data: todos.map((todo) => new Todo(todo)),
-      total,
-    };
   }
 
   async delete(id: string): Promise<void> {
@@ -92,6 +74,7 @@ export class PrismaTodoRepository implements TodoRepository {
         where: {
           owner_user_id,
         },
+        orderBy: { created_at: 'desc' },
         skip: offset,
         take: limit,
       }),


### PR DESCRIPTION
## Resumen

Cierra el agujero de autorización en el módulo de todos: cuatro de los cinco endpoints no tenían `JwtAuthGuard`, y ningún use-case verificaba ownership.

## Qué cambia

**Controller** — `@UseGuards(JwtAuthGuard)` a nivel de clase, en lugar de por método. El default pasa a ser "protegido"; abrir un endpoint ahora requiere un opt-out explícito. Los cinco endpoints reciben `user.user_id` desde `@CurrentUser()`.

**Contrato del repositorio** — el scoping deja de ser un chequeo que el caller puede olvidar y pasa a ser parte de la firma:

- `findById(id, owner_user_id)` filtra a nivel de query (`findFirst` en vez de `findUnique`, porque el `where` compuesto ya no es único).
- Se elimina `findAll(params)`, el método sin filtro. El listado va por `findAllByOwnerUserId`, que ya existía implementado y sin usar. Se le agregó el `orderBy: created_at desc` que tenía el `findAll` que reemplaza, para no cambiar el orden del listado.

**DTO** — `owner_user_id` sale de `FindTodoDto`. El dueño sale del token, nunca del cliente.

**Semántica de error** — un todo de otro usuario devuelve **404, no 403**, para que la respuesta no confirme que el id existe.

## Tests

Un caso de acceso cruzado por cada use-case afectado, más el de `find-all` que verifica que nunca se consulte sin owner. Suite completa: **10 suites, 35 tests, en verde**. Lint y typecheck limpios.

## Notas

- `FindTodoDto.status` se sigue ignorando en el listado — `findAllByOwnerUserId` no filtra por status. Es comportamiento preexistente, fuera del alcance de este fix, pero conviene resolverlo antes de #84 para no documentar un filtro que no hace nada.
- Va antes de #86 (query params) y #84 (OpenAPI), que tocan el mismo controller.

Closes #85
