### PR TITLE
chore(MKN-86): todo query params

### DIFF
--- a/src/modules/todo/infrastructure/http/dto/find.dto.spec.ts
+++ b/src/modules/todo/infrastructure/http/dto/find.dto.spec.ts
@@ -1,0 +1,54 @@
+import 'reflect-metadata';
+import { plainToInstance } from 'class-transformer';
+import { validateSync } from 'class-validator';
+import { TodoStatus } from '@prisma/client';
+import { FindTodoDto } from './find.dto';
+
+describe('FindTodoDto', () => {
+  const transform = (query: Record<string, unknown>) =>
+    plainToInstance(FindTodoDto, query, { enableImplicitConversion: false });
+
+  it('coerces numeric query strings into numbers', () => {
+    const dto = transform({ offset: '10', limit: '5' });
+
+    expect(validateSync(dto)).toHaveLength(0);
+    expect(dto.offset).toBe(10);
+    expect(dto.limit).toBe(5);
+  });
+
+  it('applies the defaults when pagination is omitted', () => {
+    const dto = transform({});
+
+    expect(validateSync(dto)).toHaveLength(0);
+    expect(dto.offset).toBe(0);
+    expect(dto.limit).toBe(20);
+  });
+
+  it('accepts a valid status filter', () => {
+    const dto = transform({ status: TodoStatus.PENDING });
+
+    expect(validateSync(dto)).toHaveLength(0);
+    expect(dto.status).toBe(TodoStatus.PENDING);
+  });
+
+  it('rejects a non-numeric limit', () => {
+    const errors = validateSync(transform({ limit: 'all' }));
+
+    expect(errors).toHaveLength(1);
+    expect(errors[0].property).toBe('limit');
+  });
+
+  it('rejects a negative offset', () => {
+    const errors = validateSync(transform({ offset: '-1' }));
+
+    expect(errors).toHaveLength(1);
+    expect(errors[0].property).toBe('offset');
+  });
+
+  it('rejects an unknown status', () => {
+    const errors = validateSync(transform({ status: 'NOT_A_STATUS' }));
+
+    expect(errors).toHaveLength(1);
+    expect(errors[0].property).toBe('status');
+  });
+});

--- a/src/modules/todo/infrastructure/http/todo.controller.ts
+++ b/src/modules/todo/infrastructure/http/todo.controller.ts
@@ -1,4 +1,14 @@
-import { Body, Controller, Delete, Get, Param, Patch, Post, UseGuards } from '@nestjs/common';
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  Param,
+  Patch,
+  Post,
+  Query,
+  UseGuards,
+} from '@nestjs/common';
 import { CreateUseCase } from '../../application/use-cases/create.use-case';
 import { FindAllUseCase } from '../../application/use-cases/find-all.use-case';
 import { FindByIdUseCase } from '../../application/use-cases/find-by-id.use-case';
@@ -23,7 +33,7 @@ export class TodoController {
   ) {}
 
   @Get()
-  async findAll(@Body() findTodoDto: FindTodoDto, @CurrentUser() user: JwtUserPayload) {
+  async findAll(@Query() findTodoDto: FindTodoDto, @CurrentUser() user: JwtUserPayload) {
     return this.findAllUseCase.execute({
       ...findTodoDto,
       owner_user_id: user.user_id,


### PR DESCRIPTION
## Resumen

`GET /todo` recibía los filtros y la paginación por `@Body()`. Este PR los pasa a query params.

Un GET con body no es estándar y trae problemas concretos: `fetch` y la mayoría de los clientes HTTP no lo permiten, así que `mikan-web` no iba a poder consumir el endpoint; Swagger UI no envía body en peticiones GET, con lo cual bloqueaba parte de #84; y una URL con filtros no se puede compartir ni cachear.

## Qué cambia

- `FindTodoDto` se bindea con `@Query()` en lugar de `@Body()`.
- No hizo falta tocar la validación: el `ValidationPipe` global ya corre con `transform: true` y `PaginationDto` ya traía `@Type(() => Number)`, así que los valores string de la query se convierten correctamente.
- Se agrega `find.dto.spec.ts` con 6 casos que fijan esa coerción y los límites de validación. Necesita `import 'reflect-metadata'` porque Jest no bootstrapea la app y los decoradores lo requieren.

El test de coerción no es ceremonia: un `limit` que se queda como string llega al `take` de Prisma y falla en runtime en vez de en validación.

## Verificación

Suite completa: **11 suites, 41 tests, en verde**. Lint, `tsc --noEmit` y `nest build` limpios.

## Notas

- Apilado sobre `fix/MKN-85-todo-auth-guard-and-ownership` (#89), porque ambos tocan el mismo controller. Retargetear a `develop` cuando ese merge.
- `FindTodoDto.status` se sigue ignorando en el listado: `findAllByOwnerUserId` no filtra por status. Es preexistente y queda fuera de alcance, pero conviene resolverlo antes de #84 para no documentar un filtro que no hace nada.

Closes #86
